### PR TITLE
rename the cx key in google search

### DIFF
--- a/blocks/tools.py
+++ b/blocks/tools.py
@@ -11,9 +11,9 @@ from .base import BaseBlock
 
 
 @functools.lru_cache
-def search_google(cx: str, key: str, query: str) -> dict:
+def search_google(google_search_id: str, key: str, query: str) -> dict:
     query = urllib.parse.quote(query)
-    url = f"https://www.googleapis.com/customsearch/v1?cx={cx}&key={key}&q={query}"
+    url = f"https://www.googleapis.com/customsearch/v1?cx={google_search_id}&key={key}&q={query}"
     return requests.get(url).json()
 
 
@@ -23,7 +23,7 @@ class GoogleSearch(BaseBlock):
     This block searches Google to find related snippets.
 
     Args:
-        cx (str): The custom search engine ID.
+        google_search_id (str): The custom search engine ID.
         key (str): Your API key.
         top_k (int, optional): The number of top results to return. Defaults to 5.
 
@@ -38,13 +38,13 @@ class GoogleSearch(BaseBlock):
         list: A list of snippets related to the search query.
     """
 
-    def __init__(self, cx: str, key: Secret, top_k=5):
-        self.cx = cx
+    def __init__(self, google_search_id: str, key: Secret, top_k=5):
+        self.google_search_id = google_search_id
         self.key = key
         self.top_k = top_k
 
     @span(name="search google")
     def __call__(self, text: str) -> list:
-        r = search_google(self.cx, self.key, text)
+        r = search_google(self.google_search_id, self.key, text)
         items = r.get("items", [])
         return [item["snippet"] for item in items[: self.top_k]]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Rename the confused key `cx` to `google_search_id`

## Related issue number

<!-- For example: "Closes #1234" -->
Close #40 

## Checks

- [ ] I've included any doc changes needed for https://github.com/pingcap/LinguFlow/.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.