### PR TITLE
observability: support trace session

### DIFF
--- a/api/api_schemas.py
+++ b/api/api_schemas.py
@@ -304,6 +304,7 @@ class ApplicationRun(APIModel):
     """The request model for trigger an app."""
 
     input: Union[str, List[str], Dict[str, str]]
+    session_id: Optional[str]
 
 
 class ApplicationRunResponse(APIModel):

--- a/api/application.py
+++ b/api/application.py
@@ -249,9 +249,10 @@ class ApplicationView:
         """
         return ApplicationRunResponse(
             id=self.invoker.invoke(
-                request.state.user,
-                application_id,
-                config.input,
+                user=request.state.user,
+                app_id=application_id,
+                input=config.input,
+                session_id=config.session_id,
             )
         )
 
@@ -372,10 +373,11 @@ class ApplicationView:
         """
         return ApplicationRunResponse(
             id=self.invoker.invoke(
-                request.state.user,
-                application_id,
-                config.input,
+                user=request.state.user,
+                app_id=application_id,
+                input=config.input,
                 version_id=version_id,
+                session_id=config.session_id,
             )
         )
 

--- a/blocks/invoke.py
+++ b/blocks/invoke.py
@@ -130,8 +130,8 @@ class AsyncInvoker:
         user: str,
         app_id: str,
         input: Union[str, dict, list],
-        version_id: str = None,
-        session_id: str = None,
+        version_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> str:
         """
         Invoke the specified application with the given input.
@@ -262,9 +262,9 @@ def invoke(
     user: str,
     app_id: str,
     input: Union[str, HashableDict, HashableList],
-    session_id: str,
-    timeout: int = 300,
-    interval: int = 10,
+    session_id: Optional[str] = None,
+    timeout: Optional[int] = 300,
+    interval: Optional[int] = 10,
 ) -> str:
     env = Env()
     env.read_env()

--- a/blocks/invoke.py
+++ b/blocks/invoke.py
@@ -4,7 +4,7 @@ import threading
 import time
 import uuid
 from datetime import datetime
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from environs import Env
 from sqlalchemy import create_engine


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add a `session_id` field on application run api. By this way, the frontend or user app can pass it's session_id when trigger a linguflow application, and langfuse can trace by session besides interaction.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've included any doc changes needed for https://github.com/pingcap/LinguFlow/.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.