### PR TITLE
tweak(ui): show hotkey menu only not focus debug input

### DIFF
--- a/ui/src/modules/app_builder/Canvas/index.tsx
+++ b/ui/src/modules/app_builder/Canvas/index.tsx
@@ -41,7 +41,7 @@ export interface BuilderCanvasProps {
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   interaction?: InteractionInfo
   errorInteraction?: ErrorInteraction
-  toobarFocusedRef: React.RefObject<boolean>
+  toolbarFocusedRef: React.RefObject<boolean>
   onNodeDragStop: NodeDragHandler
   onNodesDelete: OnNodesDelete
   onAddNode: (n: Node<BlockNodeProps>[]) => void
@@ -63,7 +63,7 @@ export const BuilderCanvas: React.FC<BuilderCanvasProps> = ({
   metadata,
   interaction,
   errorInteraction,
-  toobarFocusedRef,
+  toolbarFocusedRef,
   onClick,
   onNodeDragStop,
   onNodesDelete,
@@ -162,7 +162,7 @@ export const BuilderCanvas: React.FC<BuilderCanvasProps> = ({
     setHotKeyMenuOpened,
     menuPosition,
     menuStatus
-  } = useHotKeyMenu(toobarFocusedRef)
+  } = useHotKeyMenu(toolbarFocusedRef)
 
   useHotkeys([
     [

--- a/ui/src/modules/app_builder/Canvas/index.tsx
+++ b/ui/src/modules/app_builder/Canvas/index.tsx
@@ -41,6 +41,7 @@ export interface BuilderCanvasProps {
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   interaction?: InteractionInfo
   errorInteraction?: ErrorInteraction
+  toobarFocusedRef: React.RefObject<boolean>
   onNodeDragStop: NodeDragHandler
   onNodesDelete: OnNodesDelete
   onAddNode: (n: Node<BlockNodeProps>[]) => void
@@ -62,6 +63,7 @@ export const BuilderCanvas: React.FC<BuilderCanvasProps> = ({
   metadata,
   interaction,
   errorInteraction,
+  toobarFocusedRef,
   onClick,
   onNodeDragStop,
   onNodesDelete,
@@ -154,7 +156,13 @@ export const BuilderCanvas: React.FC<BuilderCanvasProps> = ({
   )
 
   // hot keys
-  const { events: paneEvents, hotKeyMenuOpened, setHotKeyMenuOpened, menuPosition, menuStatus } = useHotKeyMenu()
+  const {
+    events: paneEvents,
+    hotKeyMenuOpened,
+    setHotKeyMenuOpened,
+    menuPosition,
+    menuStatus
+  } = useHotKeyMenu(toobarFocusedRef)
 
   useHotkeys([
     [

--- a/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
+++ b/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
@@ -1,7 +1,7 @@
 import { getHotkeyHandler } from '@mantine/hooks'
 import { useEffect, useRef, useState } from 'react'
 
-export const useHotKeyMenu = () => {
+export const useHotKeyMenu = (toobarFocusedRef: React.RefObject<boolean>) => {
   const [menuPosition, setMenuPosition] = useState([0, 0])
   const [hotKeyMenuOpened, setHotKeyMenuOpened] = useState(false)
   const menuStatus = useRef({
@@ -29,7 +29,7 @@ export const useHotKeyMenu = () => {
   }
 
   const showHotKeyMenu = () => {
-    if (!menuStatus.current.inPane) {
+    if (!menuStatus.current.inPane || toobarFocusedRef.current) {
       return
     }
     setMenuPosition([menuStatus.current.mouseX, menuStatus.current.mouseY])

--- a/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
+++ b/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
@@ -1,7 +1,7 @@
 import { getHotkeyHandler } from '@mantine/hooks'
 import { useEffect, useRef, useState } from 'react'
 
-export const useHotKeyMenu = (toobarFocusedRef: React.RefObject<boolean>) => {
+export const useHotKeyMenu = (toolbarFocusedRef: React.RefObject<boolean>) => {
   const [menuPosition, setMenuPosition] = useState([0, 0])
   const [hotKeyMenuOpened, setHotKeyMenuOpened] = useState(false)
   const menuStatus = useRef({
@@ -29,7 +29,7 @@ export const useHotKeyMenu = (toobarFocusedRef: React.RefObject<boolean>) => {
   }
 
   const showHotKeyMenu = () => {
-    if (!menuStatus.current.inPane || toobarFocusedRef.current) {
+    if (!menuStatus.current.inPane || toolbarFocusedRef.current) {
       return
     }
     setMenuPosition([menuStatus.current.mouseX, menuStatus.current.mouseY])

--- a/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
+++ b/ui/src/modules/app_builder/Canvas/useHotKeyMenu.ts
@@ -50,6 +50,7 @@ export const useHotKeyMenu = (toobarFocusedRef: React.RefObject<boolean>) => {
     const showHotKeyMenuHandler = getHotkeyHandler([['Space', showHotKeyMenu]])
     document.body.addEventListener('keyup', showHotKeyMenuHandler)
     return () => document.body.removeEventListener('keyup', showHotKeyMenuHandler)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return {

--- a/ui/src/modules/app_builder/index.tsx
+++ b/ui/src/modules/app_builder/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import download from 'downloadjs'
 import yaml from 'js-yaml'
-import { useDebouncedValue, useDisclosure, useHotkeys } from '@mantine/hooks'
+import { useDebouncedValue, useDisclosure, useFocusWithin, useHotkeys } from '@mantine/hooks'
 import { ReactFlowProvider, useNodesInitialized, useReactFlow } from 'reactflow'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { ApplicationInfo, ApplicationVersionInfo, InteractionInfo, VersionMetadata } from '@api/linguflow.schemas'
@@ -96,6 +96,12 @@ const AppBuilder: React.FC = () => {
   const containerElem = useRef<HTMLDivElement>(null)
   const [menuOpened, setMenuOpened] = useState(false)
   const [toolbarPaneOpened, setToolbarPaneOpened] = useState(false)
+  const { ref: focusRef, focused: toolbarFocused } = useFocusWithin()
+  const toobarFocusedRef = useRef(toolbarFocused)
+
+  useEffect(() => {
+    toobarFocusedRef.current = toolbarFocused
+  }, [toolbarFocused])
 
   const [currentInteraction, setCurrentInteraction] = useState<InteractionInfo>()
   const [errorInteraction, setErrorInteraction] = useState<ErrorInteraction>()
@@ -223,6 +229,7 @@ const AppBuilder: React.FC = () => {
             metadata={verMetadata}
             interaction={currentInteraction}
             errorInteraction={errorInteraction}
+            toobarFocusedRef={toobarFocusedRef}
             onClick={() => setMenuOpened(false)}
             onNodeDragStop={() => setCanUpdate(true)}
             onRelayout={() => setCanUpdate(true)}
@@ -239,15 +246,17 @@ const AppBuilder: React.FC = () => {
             onCanSave={() => setCanSave(true)}
           />
         </Box>
-        <Toolbar
-          app={appData?.application}
-          ver={verData?.version}
-          toolbarPaneOpened={toolbarPaneOpened}
-          setToolbarPaneOpened={setToolbarPaneOpened}
-          isCreatingVersion={isCreatingVersion}
-          onUpdateCurrentInteraction={setCurrentInteraction}
-          onInteractionError={setErrorInteraction}
-        />
+        <div ref={focusRef}>
+          <Toolbar
+            app={appData?.application}
+            ver={verData?.version}
+            toolbarPaneOpened={toolbarPaneOpened}
+            setToolbarPaneOpened={setToolbarPaneOpened}
+            isCreatingVersion={isCreatingVersion}
+            onUpdateCurrentInteraction={setCurrentInteraction}
+            onInteractionError={setErrorInteraction}
+          />
+        </div>
       </Box>
     </ContainerElemProvider>
   )

--- a/ui/src/modules/app_builder/index.tsx
+++ b/ui/src/modules/app_builder/index.tsx
@@ -97,10 +97,10 @@ const AppBuilder: React.FC = () => {
   const [menuOpened, setMenuOpened] = useState(false)
   const [toolbarPaneOpened, setToolbarPaneOpened] = useState(false)
   const { ref: focusRef, focused: toolbarFocused } = useFocusWithin()
-  const toobarFocusedRef = useRef(toolbarFocused)
+  const toolbarFocusedRef = useRef(toolbarFocused)
 
   useEffect(() => {
-    toobarFocusedRef.current = toolbarFocused
+    toolbarFocusedRef.current = toolbarFocused
   }, [toolbarFocused])
 
   const [currentInteraction, setCurrentInteraction] = useState<InteractionInfo>()
@@ -229,7 +229,7 @@ const AppBuilder: React.FC = () => {
             metadata={verMetadata}
             interaction={currentInteraction}
             errorInteraction={errorInteraction}
-            toobarFocusedRef={toobarFocusedRef}
+            toolbarFocusedRef={toolbarFocusedRef}
             onClick={() => setMenuOpened(false)}
             onNodeDragStop={() => setCanUpdate(true)}
             onRelayout={() => setCanUpdate(true)}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, the hotkey menu would be invoked even when the user was focused on debug input content. After the improvement, it no longer gets invoked in such cases.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://github.com/pingcap/LinguFlow/.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.